### PR TITLE
Honnor allowed_domains

### DIFF
--- a/scrapy_redis/spiders.py
+++ b/scrapy_redis/spiders.py
@@ -28,8 +28,8 @@ class RedisMixin(object):
     def next_request(self):
         """Returns a request to be scheduled or none."""
         url = self.server.lpop(self.redis_key)
-        parsed_url = urlparse(url if url else "")
         if url:
+            parsed_url = urlparse(url if url else "")
             for u in self.allowed_Domains:
                 if parsed_url.netloc.endswith(u):
                     break;


### PR DESCRIPTION
Honnor allowed_domains for urls comming from Redis.
I am not sure that accepting any url pulled from Redis was intended. If it's not, here is a little patch to fix that.
