### PR TITLE
Fix NameError due to not defined host, port vars

### DIFF
--- a/scrapy_redis/spiders.py
+++ b/scrapy_redis/spiders.py
@@ -21,7 +21,7 @@ class RedisMixin(object):
         # idle signal is called when the spider has no requests left,
         # that's when we will schedule new requests from redis queue
         self.crawler.signals.connect(self.spider_idle, signal=signals.spider_idle)
-        self.log("Reading URLs from redis list '%s' at %s:%s." % (self.redis_key, host, port))
+        self.log("Reading URLs from redis list '%s'" % self.redis_key)
 
     def next_request(self):
         """Returns a request to be scheduled or none."""


### PR DESCRIPTION
I got this exception while trying to start a simple crawl. The simple patch should fix it.

```
Traceback (most recent call last):
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/bin/scrapy", line 4, in <module>
    execute()
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/cmdline.py", line 142, in execute
    _run_print_help(parser, _run_command, cmd, args, opts)
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/cmdline.py", line 88, in _run_print_help
    func(*a, **kw)
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/cmdline.py", line 149, in _run_command
    cmd.run(args, opts)
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/commands/crawl.py", line 49, in run
    crawler.crawl(spider)
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy/crawler.py", line 48, in crawl
    spider.set_crawler(self)
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy_redis/spiders.py", line 45, in set_crawler
    self.setup_redis()
  File "/Users/nopper/.pythonbrew/venvs/Python-2.7.3/frugal/lib/python2.7/site-packages/scrapy_redis/spiders.py", line 24, in setup_redis
    self.log("Reading URLs from redis list '%s' at %s:%s." % (self.redis_key, host, port))
NameError: global name 'host' is not defined
```
