### PR TITLE
Add support for redis-cluster

### DIFF
--- a/requirements-install.txt
+++ b/requirements-install.txt
@@ -2,3 +2,4 @@
 Scrapy>=1.0
 redis>=2.10
 six>=1.5.2
+redis-py-cluster>=1.3.4

--- a/src/scrapy_redis/connection.py
+++ b/src/scrapy_redis/connection.py
@@ -11,6 +11,7 @@ SETTINGS_PARAMS_MAP = {
     'REDIS_HOST': 'host',
     'REDIS_PORT': 'port',
     'REDIS_ENCODING': 'encoding',
+    'REDIS_CLUSTER': 'cluster',
 }
 
 
@@ -41,6 +42,8 @@ def get_redis_from_settings(settings):
         Server port.
     REDIS_ENCODING : str, optional
         Data encoding.
+    REDIS_CLUSTER : bool, optional
+        True for using reids-cluster, False for not.
     REDIS_PARAMS : dict, optional
         Additional client parameters.
 
@@ -82,7 +85,11 @@ def get_redis(**kwargs):
         Redis client instance.
 
     """
-    redis_cls = kwargs.pop('redis_cls', defaults.REDIS_CLS)
+    cluster = kwargs.pop('cluster', False)
+    if cluster:
+        redis_cls = kwargs.pop('redis_cls', defaults.REDISCLUSTER_CLS)
+    else:
+        redis_cls = kwargs.pop('redis_cls', defaults.REDIS_CLS)
     url = kwargs.pop('url', None)
     if url:
         return redis_cls.from_url(url, **kwargs)

--- a/src/scrapy_redis/defaults.py
+++ b/src/scrapy_redis/defaults.py
@@ -1,4 +1,5 @@
 import redis
+import rediscluster
 
 
 # For standalone use.
@@ -7,6 +8,7 @@ DUPEFILTER_KEY = 'dupefilter:%(timestamp)s'
 PIPELINE_KEY = '%(spider)s:items'
 
 REDIS_CLS = redis.StrictRedis
+REDISCLUSTER_CLS = rediscluster.StrictRedisCluster
 REDIS_ENCODING = 'utf-8'
 # Sane connection defaults.
 REDIS_PARAMS = {


### PR DESCRIPTION
but I don't know how to add redis-cluster into the test... sorry...

need to import rediscluster (maybe add a 'try...except' is better?)
create a new bool parameter 'REDIS_CLUSTER' , default False. When set 'REDIS_CLUSTER = True' in scrapy.settings, using 'REDISCLUSTER_CLS(rediscluster.StrictRedisCluster)' instead of 'REDIS_CLS(redis.StrictRedis)' to connect to a redis-cluster.