### PR TITLE
Add option to decode responses in python3

### DIFF
--- a/src/scrapy_redis/connection.py
+++ b/src/scrapy_redis/connection.py
@@ -1,3 +1,5 @@
+import sys
+
 import six
 
 from scrapy.utils.misc import load_object
@@ -12,6 +14,9 @@ SETTINGS_PARAMS_MAP = {
     'REDIS_PORT': 'port',
     'REDIS_ENCODING': 'encoding',
 }
+
+if sys.version_info > (3,):
+    SETTINGS_PARAMS_MAP['REDIS_DECODE_RESPONSES'] = 'decode_responses'
 
 
 def get_redis_from_settings(settings):
@@ -43,6 +48,11 @@ def get_redis_from_settings(settings):
         Data encoding.
     REDIS_PARAMS : dict, optional
         Additional client parameters.
+
+    Python 3 Only
+    ----------------
+    REDIS_DECODE_RESPONSES : bool, optional
+        Sets the `decode_responses` kwarg in Redis cls ctor
 
     """
     params = defaults.REDIS_PARAMS.copy()


### PR DESCRIPTION
In redis-py on python 3 we have the option to construct our redis class with the kwarg
`decode_responses=True` which will decode bytes received from redis requests to python 3 strings ('utf-8')

This is really useful behavior because without it we have to decode all bytes before we use them, (not hard but tedious). 

This PR adds a setting to enable that behavior in python versions > (3,)