### PR TITLE
fix(example): update dmoz spider domain

### DIFF
--- a/example-project/example/spiders/dmoz.py
+++ b/example-project/example/spiders/dmoz.py
@@ -5,8 +5,8 @@ from scrapy.spiders import CrawlSpider, Rule
 class DmozSpider(CrawlSpider):
     """Follow categories and extract links."""
     name = 'dmoz'
-    allowed_domains = ['dmoz.org']
-    start_urls = ['http://www.dmoz.org/']
+    allowed_domains = ['dmoz-odp.org']
+    start_urls = ['http://www.dmoz-odp.org/']
 
     rules = [
         Rule(LinkExtractor(


### PR DESCRIPTION
It seems dmoz.org is nolonger alive. It has been replaced by dmoz-odp.org.