### PR TITLE
Added maximum idle waiting time MAX_IDLE_TIME_BEFORE_CLOSE.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,12 @@ Use the following settings in your project:
   # and may also block the same time when your spider start at the first time (because the queue is empty).
   #SCHEDULER_IDLE_BEFORE_CLOSE = 10
 
+  # Maximum idle time before close spider.
+  # When the number of idle seconds is greater than MAX_IDLE_TIME_BEFORE_CLOSE, the crawler will close.
+  # If 0, the crawler will DontClose forever to wait for the next request.
+  # If negative number, the crawler will immediately close when the queue is empty, just like Scrapy.
+  #MAX_IDLE_TIME_BEFORE_CLOSE = 0
+
   # Store scraped item in redis for post-processing.
   ITEM_PIPELINES = {
       'scrapy_redis.pipelines.RedisPipeline': 300


### PR DESCRIPTION
新增空闲最大等待时间MAX_IDLE_TIME_BEFORE_CLOSE.
在设置中使用MAX_IDLE_TIME_BEFORE_CLOSE来表示最大的等待秒数.
不设置或为0时，则会一直等待.
MAX_IDLE_TIME_BEFORE_CLOSE不会影响SCHEDULER_IDLE_BEFORE_CLOSE的使用.
----------------------------
Added maximum idle waiting time MAX_IDLE_TIME_BEFORE_CLOSE.
Use MAX_IDLE_TIME_BEFORE_CLOSE in the settings to indicate the maximum number of seconds to wait.
If it is not set or 0, it will wait forever.
MAX_IDLE_TIME_BEFORE_CLOSE will not affect the use of SCHEDULER_IDLE_BEFORE_CLOSE.
