### PR TITLE
doc: fix redis-py dependency version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Requirements
 * Python 2.7, 3.4 or 3.5
 * Redis >= 2.8
 * ``Scrapy`` >= 1.1
-* ``redis-py`` >= 2.10
+* ``redis-py`` >= 3.0
 
 Usage
 -----

--- a/requirements-install.txt
+++ b/requirements-install.txt
@@ -1,4 +1,4 @@
 # This packages are required to install and run our package.
 Scrapy>=1.0
-redis>=2.10
+redis>=3.0
 six>=1.5.2


### PR DESCRIPTION
 In redis-py < 3.0, `redis.Redis.spop()` takes only two arguments which are `self` and `name`. But `self.fetch_data(self.redis_key, self.redis_batch_size)` applies `self` and two other arguments to self.fetch_data which is `redis.Redis.spop()` indeed. This could cause an error `TypeError: spop() takes 2 positional arguments but 3 were given`