### PR TITLE
Fix RedisStatsCollector._get_key()

### DIFF
--- a/src/scrapy_redis/stats.py
+++ b/src/scrapy_redis/stats.py
@@ -21,7 +21,7 @@ class RedisStatsCollector(StatsCollector):
     def _get_key(self, spider=None):
         """Return the hash name of stats"""
         if spider:
-            self.stats_key % {'spider': spider.name}
+            return self.stats_key % {'spider': spider.name}
         if self.spider:
             return self.stats_key % {'spider': self.spider.name}
         return self.stats_key % {'spider': self.spider_name or 'scrapy'}


### PR DESCRIPTION
Return the stats_key correctly if `spider` is passed in `._get_key(spider)`.