### PR TITLE
Remove python 2.x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ENDC = "\033[0m"
 try:
 	from urllib.request import pathname2url
 except:
-	print(FAIL + "Python2 is deprecated, please upgrade your python >= 3.6" + ENDC)
+	print(FAIL + "Python2 is deprecated, please upgrade your python >= 3.7" + ENDC)
 
 webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@
 .PHONY: release dist install build-inplace
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
+FAIL = "\033[91m"
+ENDC = "\033[0m"
+
 try:
-	from urllib import pathname2url
-except:
 	from urllib.request import pathname2url
+except:
+	print(FAIL + "Python2 is deprecated, please upgrade your python >= 3.6" + ENDC)
 
 webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef


### PR DESCRIPTION
fix #226 

## Description
`Makefile` hasn't update for a long while, needs to check whether works functionally as expected or not and removes `python 2.x` support.

## Solution
* Check each command works functionally or not.
* Remove `python 2.x` support and add a warning message.