### PR TITLE
Update import scrapy_redis.utils

### DIFF
--- a/src/scrapy_redis/spiders.py
+++ b/src/scrapy_redis/spiders.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from scrapy import signals, FormRequest
 from scrapy.exceptions import DontCloseSpider
 from scrapy.spiders import Spider, CrawlSpider
-from scrapy_redis import TextColor
+from scrapy_redis.utils import TextColor
 import time
 
 from . import connection, defaults


### PR DESCRIPTION
## Description
An error `scrapy_redis has no module TextColor` occurred when perform `tox` test

## Solution
Change `from scrapy_redis import TextColor` to `from scrapy_redis.utils import TextColor` in spiders.py