### PR TITLE
Dev tox matrix

### DIFF
--- a/src/scrapy_redis/queue.py
+++ b/src/scrapy_redis/queue.py
@@ -1,4 +1,7 @@
-from scrapy.utils.request import request_from_dict
+try:
+    from scrapy.utils.request import request_from_dict
+except:
+    from scrapy.utils.reqser import request_to_dict, request_from_dict
 
 from . import picklecompat
 
@@ -39,7 +42,10 @@ class Base(object):
 
     def _encode_request(self, request):
         """Encode a request object"""
-        obj = request.to_dict(spider=self.spider)
+        try:
+            obj = request.to_dict(spider=self.spider)
+        except:
+            obj = request_to_dict(request, self.spider)
         return self.serializer.dumps(obj)
 
     def _decode_request(self, encoded_request):

--- a/src/scrapy_redis/queue.py
+++ b/src/scrapy_redis/queue.py
@@ -1,6 +1,6 @@
 try:
     from scrapy.utils.request import request_from_dict
-except:
+except ImportError:
     from scrapy.utils.reqser import request_to_dict, request_from_dict
 
 from . import picklecompat
@@ -44,7 +44,7 @@ class Base(object):
         """Encode a request object"""
         try:
             obj = request.to_dict(spider=self.spider)
-        except:
+        except AttributeError:
             obj = request_to_dict(request, self.spider)
         return self.serializer.dumps(obj)
 

--- a/src/scrapy_redis/utils.py
+++ b/src/scrapy_redis/utils.py
@@ -15,11 +15,13 @@ class TextColor:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+
 def bytes_to_str(s, encoding='utf-8'):
     """Returns a str if a bytes object is given."""
     if six.PY3 and isinstance(s, bytes):
         return s.decode(encoding)
     return s
+
 
 def is_dict(string_content):
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 # TODO: added redis-py version matrix.
-# TODO: envlist = py{27,34,35}-scrapy{10,11,12,1x,rel,dev}
-envlist = security,flake8,py37,py38,py39,py310
+envlist = security,flake8,py{37,38,39,310}-scrapy{18,25,26}
 minversion = 1.7.0
 
 [base]
 deps = 
-    scrapy>=2.4
     redis>=4.0
     six>=1.5.2
 
@@ -22,6 +20,9 @@ deps =
     pytest
     pytest-cov
 commands = 
+    scrapy18: pip install scrapy==1.8.2
+    scrapy25: pip install scrapy==2.5.1
+    scrapy26: pip install scrapy==2.6.1
     pip install .
     python -m pytest --ignore=setup.py # --cov-report term --cov=scrapy_redis
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-# TODO: added redis-py version matrix.
-envlist = security,flake8,py{37,38,39,310}-scrapy{18,25,26}
+envlist = security,flake8,py{37,38,39,310}-scrapy{18,25,26}-redis{40,41,42}
 minversion = 1.7.0
 
 [base]
 deps = 
+    scrapy>=2.5
     redis>=4.0
     six>=1.5.2
 
 [testenv]
-basepython = 
+basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
@@ -23,6 +23,9 @@ commands =
     scrapy18: pip install scrapy==1.8.2
     scrapy25: pip install scrapy==2.5.1
     scrapy26: pip install scrapy==2.6.1
+    redis40: pip install redis==4.0.2
+    redis41: pip install redis=4.1.4
+    redis42: pip install redis=4.2.2
     pip install .
     python -m pytest --ignore=setup.py # --cov-report term --cov=scrapy_redis
 


### PR DESCRIPTION
## Description

`scrapy-redis` relies on `python`, `scrapy`, `redis` work with each other, so there's a lot of combination to test

## Solution

Use `tox` with `matrix` testing `python`, `scrapy`, `redis`'s combinations.