### PR TITLE
[style] Fix pylint style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,8 +51,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Scrapy-Redis'
-copyright = u'2011-2016, Rolando Espinoza'
+project = 'Scrapy-Redis'
+copyright = '2011-2016, Rolando Espinoza'
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -205,8 +205,8 @@ latex_elements = {
 # [howto/manual]).
 latex_documents = [
     ('index', 'scrapy_redis.tex',
-     u'Scrapy-Redis Documentation',
-     u'Rolando Espinoza', 'manual'),
+     'Scrapy-Redis Documentation',
+     'Rolando Espinoza', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at
@@ -236,8 +236,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'scrapy_redis',
-     u'Scrapy-Redis Documentation',
-     [u'Rolando Espinoza'], 1)
+     'Scrapy-Redis Documentation',
+     ['Rolando Espinoza'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -251,8 +251,8 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'scrapy_redis',
-     u'Scrapy-Redis Documentation',
-     u'Rolando Espinoza',
+     'Scrapy-Redis Documentation',
+     'Rolando Espinoza',
      'scrapy-redis',
      'One line description of project.',
      'Miscellaneous'),

--- a/src/scrapy_redis/queue.py
+++ b/src/scrapy_redis/queue.py
@@ -26,11 +26,9 @@ class Base(object):
             # TODO: deprecate pickle.
             serializer = picklecompat
         if not hasattr(serializer, 'loads'):
-            raise TypeError("serializer does not implement 'loads' function: %r"
-                            % serializer)
+            raise TypeError(f"serializer does not implement 'loads' function: {serializer}")
         if not hasattr(serializer, 'dumps'):
-            raise TypeError("serializer '%s' does not implement 'dumps' function: %r"
-                            % serializer)
+            raise TypeError(f"serializer does not implement 'dumps' function: {serializer}")
 
         self.server = server
         self.spider = spider

--- a/src/scrapy_redis/scheduler.py
+++ b/src/scrapy_redis/scheduler.py
@@ -131,8 +131,7 @@ class Scheduler(object):
                 serializer=self.serializer,
             )
         except TypeError as e:
-            raise ValueError("Failed to instantiate queue class '%s': %s",
-                             self.queue_cls, e)
+            raise ValueError(f"Failed to instantiate queue class '{self.queue_cls}': {e}")
 
         self.df = load_object(self.dupefilter_cls).from_spider(spider)
 
@@ -140,7 +139,7 @@ class Scheduler(object):
             self.flush()
         # notice if there are requests already in the queue to resume the crawl
         if len(self.queue):
-            spider.log("Resuming crawl (%d requests scheduled)" % len(self.queue))
+            spider.log(f"Resuming crawl ({len(self.queue)} requests scheduled)")
 
     def close(self, reason):
         if not self.persist:

--- a/src/scrapy_redis/spiders.py
+++ b/src/scrapy_redis/spiders.py
@@ -133,10 +133,10 @@ class RedisMixin(object):
                 yield reqs
                 found += 1
             else:
-                self.logger.debug("Request not made from data: %r", data)
+                self.logger.debug(f"Request not made from data: {data}")
 
         if found:
-            self.logger.debug("Read %s requests from '%s'", found, self.redis_key)
+            self.logger.debug(f"Read {found} requests from '{self.redis_key}'")
 
     def make_request_from_data(self, data):
         """
@@ -176,12 +176,12 @@ class RedisMixin(object):
         if is_dict(formatted_data):
             parameter = json.loads(formatted_data)
         else:
-            self.logger.warning(TextColor.WARNING + "WARNING: String request is deprecated, please use JSON data format. \
-                Detail information, please check https://github.com/rmax/scrapy-redis#features" + TextColor.ENDC)
+            self.logger.warning(f"{TextColor.WARNING}WARNING: String request is deprecated, please use JSON data format. \
+                Detail information, please check https://github.com/rmax/scrapy-redis#features{TextColor.ENDC}")
             return FormRequest(formatted_data, dont_filter=True)
 
         if parameter.get('url', None) is None:
-            self.logger.warning(TextColor.WARNING + "The data from Redis has no url key in push data" + TextColor.ENDC)
+            self.logger.warning(f"{TextColor.WARNING}The data from Redis has no url key in push data{TextColor.ENDC}")
             return []
 
         url = parameter.pop("url")

--- a/tests/test_picklecompat.py
+++ b/tests/test_picklecompat.py
@@ -10,9 +10,9 @@ def test_picklecompat():
         'dont_filter': False,
         'errback': None,
         'headers': {'Referer': ['http://www.dmoz.org/']},
-        'meta': {'depth': 1, 'link_text': u'Fran\xe7ais', 'rule': 0},
+        'meta': {'depth': 1, 'link_text': 'Fran\xe7ais', 'rule': 0},
         'method': 'GET',
         'priority': 0,
-        'url': u'http://www.dmoz.org/World/Fran%C3%A7ais/',
+        'url': 'http://www.dmoz.org/World/Fran%C3%A7ais/',
     }
     assert obj == picklecompat.loads(picklecompat.dumps(obj))

--- a/tests/test_scrapy_redis.py
+++ b/tests/test_scrapy_redis.py
@@ -63,7 +63,7 @@ class QueueTestMixin(RedisTestMixin):
 
     def setUp(self):
         self.spider = get_spider(name='myspider')
-        self.key = 'scrapy_redis:tests:%s:queue' % self.spider.name
+        self.key = f'scrapy_redis:tests:{self.spider.name}:queue'
         self.q = self.queue_cls(self.server, Spider('myspider'), self.key)
 
     def tearDown(self):
@@ -80,7 +80,7 @@ class QueueTestMixin(RedisTestMixin):
             # duplication filter whenever the serielized requests are the same.
             # This might be unwanted on repetitive requests to the same page
             # even with dont_filter=True flag.
-            req = Request('http://example.com/?page=%s' % i)
+            req = Request(f'http://example.com/?page={i}')
             self.q.push(req)
         self.assertEqual(len(self.q), 10)
 

--- a/tests/test_spiders.py
+++ b/tests/test_spiders.py
@@ -109,7 +109,7 @@ class MockRequest(mock.Mock):
         return hash(self.url)
 
     def __repr__(self):
-        return '<%s(%s)>' % (self.__class__.__name__, self.url)
+        return f'<{self.__class__.__name__}({self.url})>'
 
 
 @pytest.mark.parametrize('spider_cls', [
@@ -132,7 +132,7 @@ def test_consume_urls_from_redis(start_urls_as_zset, start_urls_as_set, spider_c
     spider = spider_cls.from_crawler(crawler)
     with flushall(spider.server):
         urls = [
-            'http://example.com/%d' % i for i in range(batch_size * 2)
+            f'http://example.com/{i}' for i in range(batch_size * 2)
         ]
         reqs = []
         if start_urls_as_set:


### PR DESCRIPTION
## Description
Convert string to fstring format, to follow `pylint` rules.

upstream PR #247 
fix #245 

## Solution
For example
```python
raise ValueError("Failed to instantiate queue class '%s': %s", self.queue_cls, e)
# to
raise ValueError(f"Failed to instantiate queue class '{self.queue_cls}':  {e}")
```