### PR TITLE
[spiders] Remove duplicate check setting types

### DIFF
--- a/src/scrapy_redis/spiders.py
+++ b/src/scrapy_redis/spiders.py
@@ -58,9 +58,9 @@ class RedisMixin(object):
 
         if self.redis_batch_size is None:
             # TODO: Deprecate this setting (REDIS_START_URLS_BATCH_SIZE).
-            self.redis_batch_size = settings.getint(
+            self.redis_batch_size = settings.get(
                 'REDIS_START_URLS_BATCH_SIZE',
-                settings.getint('CONCURRENT_REQUESTS'),
+                settings.get('CONCURRENT_REQUESTS'),
             )
 
         try:
@@ -88,7 +88,7 @@ class RedisMixin(object):
             self.count_size = self.server.llen
 
         if self.max_idle_time is None:
-            self.max_idle_time = settings.getint(
+            self.max_idle_time = settings.get(
                 "MAX_IDLE_TIME_BEFORE_CLOSE",
                 defaults.MAX_IDLE_TIME
             )

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     {[base]deps}
     flake8 # https://github.com/tholo/pytest-flake8/issues/81
 commands =
-    flake8 docs/ tests/
+    flake8 --ignore=W503,E265,E731 docs/ tests/
 
 [testenv:security]
 basepython = python3.10


### PR DESCRIPTION
# Description

When a spider get parameter from settings, there's a duplicate type checking show as follow.
```python
if self.redis_batch_size is None:
  self.redis_batch_size = settings.getint('CONCURRENT_REQUESTS', defaults.REDIS_CONCURRENT_REQUESTS)
try:
  self.redis_batch_size = int(self.redis_batch_size)
except (TypeError, ValueError):
  raise ValueError("redis_batch_size must be an integer")
```

Fixes #260 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] tox -e py310
- [x] tox -e flake8
- [x] tox -e security
- [x] tox -e pylint

# Test Configuration:
- OS version: Ubuntu 21.04
- Necessary Libraries (optional):

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
