### PR TITLE
fix(sec): upgrade scrapy to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scrapy>=2.0
+scrapy>=2.6.0
 redis>=4.0
 six>=1.15
 coverage


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scrapy 2.0
- [CVE-2022-0577](https://www.oscs1024.com/hd/CVE-2022-0577)


### What did I do？
Upgrade scrapy from 2.0 to 2.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.