### PR TITLE
[dev] Deprecated function scrapy.utils.request.request_fingerprint() warning

### DIFF
--- a/src/scrapy_redis/dupefilter.py
+++ b/src/scrapy_redis/dupefilter.py
@@ -2,7 +2,8 @@ import logging
 import time
 
 from scrapy.dupefilters import BaseDupeFilter
-from scrapy.utils.request import request_fingerprint
+#from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import fingerprint
 
 from . import defaults
 from .connection import get_redis_from_settings
@@ -95,12 +96,12 @@ class RFPDupeFilter(BaseDupeFilter):
         bool
 
         """
-        fp = self.request_fingerprint(request)
+        fp = self.fingerprint(request)
         # This returns the number of values added, zero if already exists.
         added = self.server.sadd(self.key, fp)
         return added == 0
 
-    def request_fingerprint(self, request):
+    def fingerprint(self, request):
         """Returns a fingerprint for a given request.
 
         Parameters
@@ -112,7 +113,7 @@ class RFPDupeFilter(BaseDupeFilter):
         str
 
         """
-        return request_fingerprint(request)
+        return fingerprint(request)
 
     @classmethod
     def from_spider(cls, spider):

--- a/tests/test_dupefilter.py
+++ b/tests/test_dupefilter.py
@@ -33,11 +33,11 @@ class TestRFPDupeFilter(object):
         assert not self.df.request_seen(req)
         assert self.df.request_seen(req)
 
-    def test_overridable_request_fingerprinter(self):
+    def test_overridable_fingerprinter(self):
         req = Request('http://example.com')
-        self.df.request_fingerprint = mock.Mock(wraps=self.df.request_fingerprint)
+        self.df.fingerprint = mock.Mock(wraps=self.df.fingerprint)
         assert not self.df.request_seen(req)
-        self.df.request_fingerprint.assert_called_with(req)
+        self.df.fingerprint.assert_called_with(req)
 
     def test_clear_deletes(self):
         self.df.clear()


### PR DESCRIPTION
# Description

> scrapy offical recommend use `crawler.request_fingerprinter.fingerprint()` or `scrapy.utils.request.fingerprint()` to replace `scrapy.utils.request.request_fingerprint()`.

`scrapy.utils.request.request_fingerprint()` is about to deprecated.

Fixes #272

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] tox

# Test Configuration:
- OS version: Ubuntu 20.04
- Necessary Libraries (optional):

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
