### PR TITLE
[rollback] Rollback `request_fingerprint`

### DIFF
--- a/src/scrapy_redis/dupefilter.py
+++ b/src/scrapy_redis/dupefilter.py
@@ -2,8 +2,7 @@ import logging
 import time
 
 from scrapy.dupefilters import BaseDupeFilter
-#from scrapy.utils.request import request_fingerprint
-from scrapy.utils.request import fingerprint
+from scrapy.utils.request import request_fingerprint
 
 from . import defaults
 from .connection import get_redis_from_settings
@@ -96,12 +95,12 @@ class RFPDupeFilter(BaseDupeFilter):
         bool
 
         """
-        fp = self.fingerprint(request)
+        fp = self.request_fingerprint(request)
         # This returns the number of values added, zero if already exists.
         added = self.server.sadd(self.key, fp)
         return added == 0
 
-    def fingerprint(self, request):
+    def request_fingerprint(self, request):
         """Returns a fingerprint for a given request.
 
         Parameters
@@ -113,7 +112,7 @@ class RFPDupeFilter(BaseDupeFilter):
         str
 
         """
-        return fingerprint(request)
+        return request_fingerprint(request)
 
     @classmethod
     def from_spider(cls, spider):


### PR DESCRIPTION
# Description

`request_fingerprint` is about to deprecate, but the new `fingerprint` has a different implementation. So I think we should rollback to the `request_fingerprint` for the moment, and implement our own `request_fingerprint` later, follow the old `request_fingerprint` settings.

Fixes #275

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] pytest
- [] Other test (please specify)

# Test Configuration:
- OS version: Window10
- Necessary Libraries (optional):

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
